### PR TITLE
alternative x=x fix, plus handling {cluster} better

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ LazyData: true
 Authors@R: as.person(c("Will Cornwell <wcornwell@gmail.com> [aut, cre]"))
 Maintainer: Will Cornwell <wcornwell@gmail.com>
 Imports:
-  ggmap (>= 2.6.1),
-  cluster
+  ggmap (>= 2.6.1)
 Suggests: 
-  testthat
+  testthat,
+  cluster
 RoxygenNote: 5.0.1

--- a/R/earth.R
+++ b/R/earth.R
@@ -24,7 +24,9 @@
 ##' uluru<-get_earthtones(latitude = -25.5,
 ##' longitude = 131,zoom=12,number_of_colors=5)
 ##' print(uluru)
+##' plot(uluru)
 ##' 
+##' \dontrun{
 ##' world<-get_earthtones(latitude = 0,longitude = 0,
 ##' zoom=2,number_of_colors=8)
 ##' plot(world)
@@ -36,15 +38,17 @@
 ##' joshua_tree<-get_earthtones(latitude = 33.9, 
 ##'  longitude = -115.9,zoom=9,number_of_colors=5)
 ##' plot(joshua_tree)
-##' 
+##'  
+##' ## Compare clustering methods
 ##' par(mfrow=c(2,1))
 ##' bahamas<-get_earthtones(latitude = 24.2,longitude=-77.88,
-##' zoom=11,number_of_colors=5)
+##' zoom=11,number_of_colors=5,sampleRate=500)
 ##' plot(bahamas)
 ##' 
 ##' bahamas<-get_earthtones(latitude = 24.2,longitude=-77.88,
 ##' zoom=11,number_of_colors=5,method='pam',sampleRate=500)
 ##' plot(bahamas)
+##' }
 ##' 
 ##' 
 ##' 
@@ -103,7 +107,7 @@ plot.palette <- function(x, ...) {
 ##' uluru<-plot_satellite_image_and_pallette(latitude = -25.5,
 ##' longitude = 131,zoom=10)
 ##' 
-##' 
+##' \dontrun{
 ##' world<-plot_satellite_image_and_pallette(latitude = 0,longitude = 0,
 ##' zoom=2,number_of_colors=4)
 ##' 
@@ -122,6 +126,8 @@ plot.palette <- function(x, ...) {
 ##' 
 ##' grand_canyon<-plot_satellite_image_and_pallette(latitude = 36.094994,
 ##' longitude=-111.837962,zoom=12,number_of_colors=6)
+##' }
+##' 
 ##' 
 
 plot_satellite_image_and_pallette <- function(latitude = 24.2,longitude=-77.88,zoom=11,
@@ -136,7 +142,7 @@ plot_satellite_image_and_pallette <- function(latitude = 24.2,longitude=-77.88,z
 
 
 
-get_colors_from_map<-function(map,number_of_colors,clust.method=method,subsampleRate=sampleRate){
+get_colors_from_map<-function(map,number_of_colors,clust.method,subsampleRate){
   if (subsampleRate < 300 & clust.method=="pam") {
     message("Pam can be slow, consider a larger sampleRate?")
   }
@@ -151,7 +157,7 @@ get_colors_from_map<-function(map,number_of_colors,clust.method=method,subsample
   }
   if (clust.method=="pam"){
     if (!requireNamespace("cluster",quietly=TRUE)) {
-      stop("The 'cluster' package is needed for method='pam'. Please install it.",
+      stop("The 'cluster' package is needed for cluster.method='pam'. Please install it.",
            call. = FALSE)
     }
     out<-cluster::pam(x=lab.restructure,k=number_of_colors,diss=FALSE)
@@ -159,6 +165,3 @@ get_colors_from_map<-function(map,number_of_colors,clust.method=method,subsample
   }
   return(rgb(out.rgb))
 }
-
-
-  

--- a/man/get_earthtones.Rd
+++ b/man/get_earthtones.Rd
@@ -5,7 +5,7 @@
 \title{earthtones}
 \usage{
 get_earthtones(latitude = 50.759, longitude = -125.673, zoom = 11,
-  number_of_colors = 3, method = "kmeans", sampleRate = 50)
+  number_of_colors = 3, method = "kmeans", sampleRate = 500)
 }
 \arguments{
 \item{latitude}{}
@@ -29,7 +29,9 @@ Getting a color scheme from a place on earth
 uluru<-get_earthtones(latitude = -25.5,
 longitude = 131,zoom=12,number_of_colors=5)
 print(uluru)
+plot(uluru)
 
+\dontrun{
 world<-get_earthtones(latitude = 0,longitude = 0,
 zoom=2,number_of_colors=8)
 plot(world)
@@ -41,15 +43,17 @@ plot(british_columbia_glacier)
 joshua_tree<-get_earthtones(latitude = 33.9, 
  longitude = -115.9,zoom=9,number_of_colors=5)
 plot(joshua_tree)
-
+ 
+## Compare clustering methods
 par(mfrow=c(2,1))
 bahamas<-get_earthtones(latitude = 24.2,longitude=-77.88,
-zoom=11,number_of_colors=5)
+zoom=11,number_of_colors=5,sampleRate=500)
 plot(bahamas)
 
 bahamas<-get_earthtones(latitude = 24.2,longitude=-77.88,
 zoom=11,number_of_colors=5,method='pam',sampleRate=500)
 plot(bahamas)
+}
 
 
 

--- a/man/plot_satellite_image_and_pallette.Rd
+++ b/man/plot_satellite_image_and_pallette.Rd
@@ -5,8 +5,7 @@
 \title{plot_satellite_image_and_pallette}
 \usage{
 plot_satellite_image_and_pallette(latitude = 24.2, longitude = -77.88,
-  zoom = 11, number_of_colors = 2, method = "kmeans",
-  sampleRate = sampleRate)
+  zoom = 11, number_of_colors = 2, method = "kmeans", sampleRate = 50)
 }
 \arguments{
 \item{latitude}{}
@@ -31,7 +30,7 @@ as a side product, it plots a map of the satellite image along with the color pa
 uluru<-plot_satellite_image_and_pallette(latitude = -25.5,
 longitude = 131,zoom=10)
 
-
+\dontrun{
 world<-plot_satellite_image_and_pallette(latitude = 0,longitude = 0,
 zoom=2,number_of_colors=4)
 
@@ -50,6 +49,8 @@ longitude=-60.49666,zoom=10,number_of_colors=3)
 
 grand_canyon<-plot_satellite_image_and_pallette(latitude = 36.094994,
 longitude=-111.837962,zoom=12,number_of_colors=6)
+}
+
 
 }
 

--- a/tests/testthat/test-earth.R
+++ b/tests/testthat/test-earth.R
@@ -4,3 +4,13 @@ context("earthtone")
 test_that("returns normal", {
   expect_is(get_earthtones(),"palette")
 })
+
+test_that("test stop() errors", {
+  expect_error(expr = earthtones::get_earthtones(method="42"), message = "method.*")
+  expect_error(expr = if (!requireNamespace("cluster",quietly=TRUE)) {
+    earthtones::get_earthtones(method="pam")
+    } else {
+      stop("method")
+    },
+    message = "method.*")
+})


### PR DESCRIPTION
So, I think a more elegant way of handling the x=x thing, additional to what you've done, is to also remove a default argument binding from get_colors_from_map(). I also wanted to try moving cluster back to Suggests: and try handling it with requireNamespace() - more for my own testing, rather than it actually being important for earthtones haha
